### PR TITLE
Fix typo in German translation

### DIFF
--- a/core/src/main/res/values-de/dashboard_strings.xml
+++ b/core/src/main/res/values-de/dashboard_strings.xml
@@ -26,7 +26,7 @@
     <string name="menu_select_all">Alles auswählen</string>
     <string name="menu_wallpaper_crop">Hintergrundbild zuschneiden</string>
     <string name="menu_apply_homescreen">Startbildschirm</string>
-    <string name="menu_apply_lockscreen">Speerbildschirm</string>
+    <string name="menu_apply_lockscreen">Sperrbildschirm</string>
     <!-- Dialog -->
     <string name="open">Öffnen</string>
     <string name="close">Schließen</string>


### PR DESCRIPTION
In the German translation "Sperrbildschirm" was accidentally written as "Speerbildschirm"